### PR TITLE
Initialize reader list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Download and run the installer for your platform:
 
 **Option A: CDN (recommended)**
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@cardid/webcard/dist/webcard.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@cardid/webcard/dist/webcard.iife.js"></script>
 ```
 
 **Option B: ES Module**
 ```html
 <script type="module">
-  import 'https://esm.run/@cardid/webcard';
+  import 'https://cdn.jsdelivr.net/npm/@cardid/webcard/dist/webcard.min.js';
   // navigator.webcard is now available
 </script>
 ```

--- a/example/app.js
+++ b/example/app.js
@@ -137,6 +137,7 @@ async function sendCommands() {
     sendBtn.disabled = true;
 
     try {
+        let startTime = Date.now();
         // Connect to card (shared mode)
         const atr = await reader.connect(true);
         output.textContent += `Connected. ATR: ${atr}\n\n`;
@@ -154,7 +155,7 @@ async function sendCommands() {
 
         // Disconnect
         await reader.disconnect();
-        output.textContent += 'Disconnected.';
+        output.textContent += `Disconnected. (${Date.now() - startTime} ms)`;
 
     } catch (err) {
         output.textContent += `Error: ${err.message || 'Connection failed'}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardid/webcard",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Smart card browser extension library - enables web applications to communicate with local smart card readers via APDU commands",
   "main": "dist/webcard.min.js",
   "module": "dist/webcard.min.js",

--- a/src/webcard.js
+++ b/src/webcard.js
@@ -4,7 +4,7 @@
 /******************************************************************************/
 'use strict';
 
-const WEBCARD_VERSION = '0.4.0';
+const WEBCARD_VERSION = '0.4.1';
 const WEBCARD_HOMEPAGE = 'https://webcard.cardid.org';
 
 /******************************************************************************/
@@ -162,7 +162,8 @@ function WebCard() {
     }
 
     // Fetches list of SmartCard readers connected to the PC.
-    self.readers = () => self.send(1);
+    self.getReaders = () => self.send(1);
+    self.readers = self.getReaders;
 
     // Handling content script (Native App) responses.
     self.responseCallback = (msg) => {
@@ -301,6 +302,7 @@ function initWebCard() {
 
     if (typeof navigator.webcard === 'undefined') {
         navigator.webcard = new WebCard();
+        navigator.webcard.getReaders();
     }
 }
 


### PR DESCRIPTION
Automatically populate the reader list on WebCard initialization so events are triggered even if the user does not query the list of readers